### PR TITLE
Add simple web UI for endpoint management

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ This will start the server on `http://127.0.0.1:5000`. If you use
 `localhost` and your system prefers IPv6, you might hit another service
 listening on port 5000. Using the IPv4 address avoids that issue.
 
+## Web UI
+
+Opening `http://127.0.0.1:5000/` in your browser loads a simple UI for
+managing endpoints. It lets you register, deregister, clear, export and
+import endpoints and shows a table of all current registrations.
+
 ## Registering an endpoint
 
 Send a POST request to `/register` with a JSON body:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ listening on port 5000. Using the IPv4 address avoids that issue.
 
 ## Web UI
 
-Opening `http://127.0.0.1:5000/` in your browser loads a simple UI for
-managing endpoints. It lets you register, deregister, clear, export and
+Opening `http://127.0.0.1:5000/` in your browser loads a Bootstrap styled UI
+for managing endpoints. It lets you register, deregister, clear, export and
 import endpoints and shows a table of all current registrations.
 
 ## Registering an endpoint

--- a/mockapi/app.py
+++ b/mockapi/app.py
@@ -3,7 +3,13 @@ import json
 from flask import Flask, request, jsonify, make_response
 from .database import get_connection, init_db
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='static')
+
+
+@app.route('/')
+def ui():
+    """Serve the simple management interface."""
+    return app.send_static_file('index.html')
 
 init_db()
 

--- a/mockapi/static/index.html
+++ b/mockapi/static/index.html
@@ -3,46 +3,66 @@
 <head>
     <meta charset="utf-8">
     <title>Mock API Manager</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 20px; }
-        input, textarea, select { margin: 5px 0; width: 100%; max-width: 400px; }
-        table { border-collapse: collapse; margin-top: 20px; }
-        th, td { border: 1px solid #ccc; padding: 4px 8px; }
-    </style>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
 </head>
-<body>
-<h1>Mock API Manager</h1>
-<section>
+<body class="p-3">
+<div class="container">
+<h1 class="mb-4">Mock API Manager</h1>
+
+<section class="mb-5">
     <h2>Register Endpoint</h2>
-    <input id="reg-path" placeholder="Path">
-    <input id="reg-methods" placeholder="Methods (e.g. GET,POST)">
-    <select id="reg-type">
-        <option value="json">JSON</option>
-        <option value="html">HTML</option>
-    </select>
-    <textarea id="reg-body" placeholder="Response body"></textarea>
-    <input id="reg-status" type="number" value="200" placeholder="Status code">
-    <button id="reg-submit">Register</button>
+    <div class="row g-3">
+        <div class="col-md-6">
+            <input class="form-control" id="reg-path" placeholder="Path">
+        </div>
+        <div class="col-md-6">
+            <input class="form-control" id="reg-methods" placeholder="Methods (e.g. GET,POST)">
+        </div>
+        <div class="col-md-4">
+            <select class="form-select" id="reg-type">
+                <option value="json">JSON</option>
+                <option value="html">HTML</option>
+            </select>
+        </div>
+        <div class="col-md-8">
+            <input class="form-control" id="reg-status" type="number" value="200" placeholder="Status code">
+        </div>
+        <div class="col-12">
+            <textarea class="form-control" id="reg-body" placeholder="Response body" rows="3"></textarea>
+        </div>
+        <div class="col-12">
+            <button type="button" class="btn btn-primary" id="reg-submit">Register</button>
+        </div>
+    </div>
 </section>
-<section>
+
+<section class="mb-5">
     <h2>Deregister Endpoint</h2>
-    <input id="dereg-path" placeholder="Path">
-    <button id="dereg-submit">Deregister</button>
+    <div class="input-group">
+        <input class="form-control" id="dereg-path" placeholder="Path">
+        <button class="btn btn-danger" id="dereg-submit">Deregister</button>
+    </div>
 </section>
-<section>
+
+<section class="mb-5">
     <h2>Import / Export</h2>
-    <textarea id="import-data" placeholder="Paste JSON list to import"></textarea>
-    <button id="import-submit">Import</button>
-    <button id="export-btn">Export</button>
-    <button id="clear-btn">Clear All</button>
+    <div class="mb-3">
+        <textarea id="import-data" class="form-control" placeholder="Paste JSON list to import" rows="3"></textarea>
+    </div>
+    <button class="btn btn-success me-2" id="import-submit">Import</button>
+    <button class="btn btn-secondary me-2" id="export-btn">Export</button>
+    <button class="btn btn-warning" id="clear-btn">Clear All</button>
 </section>
+
 <section>
     <h2>Registered Endpoints</h2>
-    <table id="endpoint-table">
-        <thead><tr><th>Path</th><th>Methods</th><th>Status</th></tr></thead>
+    <table id="endpoint-table" class="table table-bordered">
+        <thead class="table-light"><tr><th>Path</th><th>Methods</th><th>Status</th></tr></thead>
         <tbody></tbody>
     </table>
 </section>
+
+</div>
 <script>
 async function refreshList() {
     const resp = await fetch('/endpoints');

--- a/mockapi/static/index.html
+++ b/mockapi/static/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Mock API Manager</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        input, textarea, select { margin: 5px 0; width: 100%; max-width: 400px; }
+        table { border-collapse: collapse; margin-top: 20px; }
+        th, td { border: 1px solid #ccc; padding: 4px 8px; }
+    </style>
+</head>
+<body>
+<h1>Mock API Manager</h1>
+<section>
+    <h2>Register Endpoint</h2>
+    <input id="reg-path" placeholder="Path">
+    <input id="reg-methods" placeholder="Methods (e.g. GET,POST)">
+    <select id="reg-type">
+        <option value="json">JSON</option>
+        <option value="html">HTML</option>
+    </select>
+    <textarea id="reg-body" placeholder="Response body"></textarea>
+    <input id="reg-status" type="number" value="200" placeholder="Status code">
+    <button id="reg-submit">Register</button>
+</section>
+<section>
+    <h2>Deregister Endpoint</h2>
+    <input id="dereg-path" placeholder="Path">
+    <button id="dereg-submit">Deregister</button>
+</section>
+<section>
+    <h2>Import / Export</h2>
+    <textarea id="import-data" placeholder="Paste JSON list to import"></textarea>
+    <button id="import-submit">Import</button>
+    <button id="export-btn">Export</button>
+    <button id="clear-btn">Clear All</button>
+</section>
+<section>
+    <h2>Registered Endpoints</h2>
+    <table id="endpoint-table">
+        <thead><tr><th>Path</th><th>Methods</th><th>Status</th></tr></thead>
+        <tbody></tbody>
+    </table>
+</section>
+<script>
+async function refreshList() {
+    const resp = await fetch('/endpoints');
+    const data = await resp.json();
+    const tbody = document.querySelector('#endpoint-table tbody');
+    tbody.innerHTML = '';
+    for (const ep of data) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${ep.path}</td><td>${ep.methods.join(', ')}</td><td>${ep.status_code}</td>`;
+        tbody.appendChild(tr);
+    }
+}
+
+document.getElementById('reg-submit').onclick = async () => {
+    const body = {
+        path: document.getElementById('reg-path').value,
+        methods: document.getElementById('reg-methods').value.split(',').map(m => m.trim()).filter(Boolean),
+        response_type: document.getElementById('reg-type').value,
+        response_body: document.getElementById('reg-body').value,
+        status_code: parseInt(document.getElementById('reg-status').value || '200')
+    };
+    await fetch('/register', {method: 'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+    refreshList();
+};
+
+document.getElementById('dereg-submit').onclick = async () => {
+    const body = {path: document.getElementById('dereg-path').value};
+    await fetch('/deregister', {method: 'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+    refreshList();
+};
+
+document.getElementById('clear-btn').onclick = async () => {
+    await fetch('/clear', {method: 'POST'});
+    refreshList();
+};
+
+document.getElementById('export-btn').onclick = async () => {
+    const resp = await fetch('/export');
+    const data = await resp.json();
+    const blob = new Blob([JSON.stringify(data, null, 2)], {type:'application/json'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'endpoints.json';
+    a.click();
+    URL.revokeObjectURL(url);
+};
+
+document.getElementById('import-submit').onclick = async () => {
+    let data;
+    try { data = JSON.parse(document.getElementById('import-data').value); }
+    catch(e){ alert('Invalid JSON'); return; }
+    await fetch('/import', {method: 'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(data)});
+    refreshList();
+};
+
+refreshList();
+</script>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -179,3 +179,8 @@ def test_import(client):
     resp = client.get("/api/bar")
     assert resp.status_code == 200
     assert resp.get_data(as_text=True) == "<p>bar</p>"
+
+def test_ui_page(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b"Mock API Manager" in resp.data


### PR DESCRIPTION
## Summary
- serve new `index.html` at the root route
- implement a simple web UI for registering, deregistering, importing and exporting endpoints
- document the Web UI in README
- test that the UI page is served

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840226b883c83338ddf3ca6078abfdd